### PR TITLE
fix: portal API update

### DIFF
--- a/backend/iaaa.cpp
+++ b/backend/iaaa.cpp
@@ -16,11 +16,11 @@ IAAA::IAAA(QObject *parent)
     , params{
           {"userName", ""},
           {"password", ""},
-          {"appid", "portal2017"},
+          {"appid", "portalPublicQuery"},
           {"otpCode", ""},
           {"smsCode", ""},
           {"randCode", ""},
-          {"redirUrl", "https://portal.pku.edu.cn/portal2017/ssoLogin.do"}
+          {"redirUrl", "https://portal.pku.edu.cn/publicQuery/ssoLogin.do?moduleID=myScore"}
       }
 {
 
@@ -35,11 +35,11 @@ IAAA::IAAA(const QString &username,
     , params{
           {"userName", username},
           {"password", password},
-          {"appid", "portal2017"},
+          {"appid", "portalPublicQuery"},
           {"otpCode", otpCode},
           {"smsCode", ""},
           {"randCode", ""},
-          {"redirUrl", "https://portal.pku.edu.cn/portal2017/ssoLogin.do"}
+          {"redirUrl", "https://portal.pku.edu.cn/publicQuery/ssoLogin.do?moduleID=myScore"}
       }
 {
     if (autologin)

--- a/backend/pkuportal.cpp
+++ b/backend/pkuportal.cpp
@@ -22,9 +22,9 @@ void PKUPortal::login(IAAA &iaaa)
     }
     QString token{iaaa.token};
     iaaa.token = QString();
-    QUrl portal_url{"https://portal.pku.edu.cn/portal2017/ssoLogin.do"};
+    QUrl portal_url{"https://portal.pku.edu.cn/publicQuery/ssoLogin.do"};
     QString rand = QString::asprintf("%.15lf", QRandomGenerator::global()->generateDouble());
-    portal_url.setQuery(IAAA::urlencode({{"_rand", rand}, {"token", token}}));
+    portal_url.setQuery(IAAA::urlencode({{"_rand", rand}, {"token", token}, {"moduleID", "myScore"}}));
     QNetworkRequest myreq{portal_url};
     myreq.setRawHeader("User-Agent", user_agent);
     myreq.setRawHeader("Host", "portal.pku.edu.cn");

--- a/backend/scoresheet.cpp
+++ b/backend/scoresheet.cpp
@@ -19,7 +19,8 @@ void ScoreSheet::online_get(PKUPortal &portal)
         return;
     }
     internalportal = &portal;
-    QNetworkRequest myreq{QUrl{"https://portal.pku.edu.cn/portal2017/bizcenter/score/retrScores.do"}};
+    QNetworkRequest myreq{QUrl{"https://portal.pku.edu.cn/publicQuery/ctrl/topic/myScore/retrScores.do"}};
+    myreq.setRawHeader("Host", "portal.pku.edu.cn");
     if (!portal.logged_in) {
         emit finished(false, "Not logged in");
         return;


### PR DESCRIPTION
PKU portal score query no longer uses portal cookie. It can be logged in using another API.
Some evidence: retScores.do can be accessed even portal is explicitly logged out